### PR TITLE
Switch to mempool.space API only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UTXO Spiciness Index (Web App)
 
-This is a static web application that helps you measure the 'spiciness' of your Bitcoin UTXOs and estimate consolidation fees. It fetches real-time data from Blockstream, mempool.space, and CoinGecko to provide accurate fee estimations in both satoshis and USD.
+This is a static web application that helps you measure the 'spiciness' of your Bitcoin UTXOs and estimate consolidation fees. All data is fetched from the mempool.space API, so the application can easily point to your own self-hosted instance.
 
 The goal of this tool is to illustrate how stacking lots of small UTXOs on-chain can impact your transaction fees, especially in a high-fee environment, and to give you a fun 'Arbitrary Spicy Unit' (ASU) score. For more details, you can refer to [this article on UTXOs](https://www.discreetlog.com/utxos/).
 
@@ -8,9 +8,9 @@ This tool is for simple use cases where you have sent bitcoin repeatedly to the 
 
 ## Features
 
--   **UTXO Fetching:** Retrieves all UTXOs for a specified Bitcoin address.
+-   **UTXO Fetching:** Retrieves all UTXOs for a specified Bitcoin address via the mempool.space API.
 -   **Real-time Fee Rates:** Fetches current recommended fee rates from mempool.space.
--   **BTC Price:** Obtains the current Bitcoin price in USD for fee conversion.
+-   **BTC Price:** Obtains the current Bitcoin price in USD from mempool.space for fee conversion.
 -   **Transaction Size Estimation:** Estimates the virtual byte (vB) size of a consolidation transaction, considering:
     -   Standard P2PKH, P2SH, Bech32 (P2WPKH), P2WSH, and Taproot address types.
     -   Automatic detection of M-of-N multisig configurations for P2SH and P2WSH addresses based on on-chain data.
@@ -21,6 +21,8 @@ This tool is for simple use cases where you have sent bitcoin repeatedly to the 
 -   **Interactive Fee Chart:** Visualizes the estimated transaction fee in USD across a range of sat/vB rates (up to 5000 sat/vB by default). It also displays the total value of the address and highlights the point where the transaction fee would exceed the address's total value.
 -   **Dynamic X-axis Scaling for Chart:** A toggle allows you to automatically scale the chart's X-axis (sat/vB) to show the fee rate at which the transaction fee would consume the entire balance of the address. This critical fee level is also displayed numerically.
 -   **User-Friendly Interface:** Presents a clear summary of UTXOs, total balance, estimated transaction size, and fee breakdowns with color-coded indicators, all within an intuitive web interface.
+
+All API calls use `mempool.space` by default. If you self-host the mempool project, update the `MEMPOOL_API_BASE` constant in `script.js` to point to your instance.
 
 ## Arbitrary Spiciness Unit (ASU) Explained
 

--- a/script.js
+++ b/script.js
@@ -7,6 +7,10 @@ let globalCurrentRate = 0; // Store current rate for chart point
 let globalPredefinedRates = {}; // Store predefined rates for chart points
 let feeChartInstance = null; // To store the Chart.js instance
 
+// Base URL for all API calls. Change this if you are running your own
+// self-hosted instance of mempool.space.
+const MEMPOOL_API_BASE = 'https://mempool.space';
+
 // Helper function to fetch data from an API
 async function fetchData(url) {
     const response = await fetch(url);
@@ -16,28 +20,28 @@ async function fetchData(url) {
     return response.json();
 }
 
-// Fetches the UTXOs for a given Bitcoin address using the Blockstream API.
+// Fetches the UTXOs for a given Bitcoin address using the mempool.space API.
 async function getUtxos(address) {
-    const url = `https://blockstream.info/api/address/${address}/utxo`;
+    const url = `${MEMPOOL_API_BASE}/api/address/${address}/utxo`;
     return await fetchData(url);
 }
 
 // Fetches the current fee rate recommendations from the mempool.space API.
 async function getFeeRates() {
-    const url = "https://mempool.space/api/v1/fees/recommended";
+    const url = `${MEMPOOL_API_BASE}/api/v1/fees/recommended`;
     return await fetchData(url);
 }
 
-// Fetches the current price of Bitcoin in USD from CoinGecko.
+// Fetches the current price of Bitcoin in USD from mempool.space.
 async function getBtcPriceUsd() {
-    const url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd";
+    const url = `${MEMPOOL_API_BASE}/api/v1/prices`;
     const data = await fetchData(url);
-    return data.bitcoin.usd;
+    return data.USD;
 }
 
 // Fetches the address details from the mempool.space API.
 async function getAddressDetails(address) {
-    const url = `https://mempool.space/api/address/${address}/txs`;
+    const url = `${MEMPOOL_API_BASE}/api/address/${address}/txs`;
     return await fetchData(url);
 }
 


### PR DESCRIPTION
## Summary
- point all API calls to mempool.space
- allow easy override of the mempool endpoint via `MEMPOOL_API_BASE`
- update README to mention mempool.space usage and configuration

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`
- `curl -s http://localhost:8000/script.js | head`

------
https://chatgpt.com/codex/tasks/task_e_68693589a1548328aad7bf8cf2e1c99c